### PR TITLE
Update comment for NewStaticReflector

### DIFF
--- a/grpcreflect.go
+++ b/grpcreflect.go
@@ -94,7 +94,7 @@ func NewReflector(namer Namer, options ...Option) *Reflector {
 // a more configurable Reflector, use NewReflector.
 //
 // The supplied strings should be fully-qualified protobuf service names (for
-// example, "acme.user.v1.UserService"). Generated connect service files
+// example, "acme.user.v1.UserService"). Generated Connect service files
 // have this declared as a constant.
 func NewStaticReflector(services ...string) *Reflector {
 	namer := &staticNames{names: services}

--- a/grpcreflect.go
+++ b/grpcreflect.go
@@ -94,7 +94,8 @@ func NewReflector(namer Namer, options ...Option) *Reflector {
 // a more configurable Reflector, use NewReflector.
 //
 // The supplied strings should be fully-qualified protobuf service names (for
-// example, "acme.user.v1.UserService").
+// example, "acme.user.v1.UserService"). Generated connect service files
+// have this declared as a constant.
 func NewStaticReflector(services ...string) *Reflector {
 	namer := &staticNames{names: services}
 	return NewReflector(namer)


### PR DESCRIPTION
Mirrors: https://github.com/bufbuild/connect-grpchealth-go/pull/12

Adding a call out to the Connect generated code on where to find the fully qualified name of the service