### PR TITLE
Fix path for V1Alpha1 handler

### DIFF
--- a/grpcreflect.go
+++ b/grpcreflect.go
@@ -41,15 +41,16 @@ func NewHandlerV1(reflector *Reflector, options ...connect.HandlerOption) (strin
 	return newHandler(reflector, "/grpc.reflection.v1.ServerReflection/", options)
 }
 
-// NewHandlerV1Alpha1 constructs an implementation of v1alpha1 of the gRPC server
+// NewHandlerV1Alpha constructs an implementation of v1alpha1 of the gRPC server
 // reflection API. It returns an HTTP handler and the path on which to mount
 // it.
 //
-// If your server must support older tools that expect v1alpha1 of the server
-// reflection API, you should use NewHandlerV1Alpha1 in addition to NewHandlerV1.
-func NewHandlerV1Alpha1(reflector *Reflector, options ...connect.HandlerOption) (string, http.Handler) {
+// If your server must support older tools that expect v1alpha of the server
+// reflection API, you should use NewHandlerV1Alpha in addition to
+// NewHandlerV1.
+func NewHandlerV1Alpha(reflector *Reflector, options ...connect.HandlerOption) (string, http.Handler) {
 	// v1 is binary-compatible with v1alpha1, so we only need to change paths.
-	return newHandler(reflector, "/grpc.reflection.v1alpha1.ServerReflection/", options)
+	return newHandler(reflector, "/grpc.reflection.v1alpha.ServerReflection/", options)
 }
 
 // Reflectors implement the underlying logic for gRPC's protobuf server

--- a/grpcreflect_test.go
+++ b/grpcreflect_test.go
@@ -32,7 +32,7 @@ import (
 func TestReflection(t *testing.T) {
 	const (
 		actualService = "connectext.grpc.reflection.v1.ServerReflection"
-		nameV1Alpha1  = "grpc.reflection.v1alpha1.ServerReflection"
+		nameV1Alpha   = "grpc.reflection.v1alpha.ServerReflection"
 		nameV1        = "grpc.reflection.v1.ServerReflection"
 	)
 	t.Parallel()
@@ -44,7 +44,7 @@ func TestReflection(t *testing.T) {
 	t.Run("v1alpha1", func(t *testing.T) {
 		t.Parallel()
 		reflector := NewStaticReflector(actualService)
-		testReflector(t, reflector, nameV1Alpha1)
+		testReflector(t, reflector, nameV1Alpha)
 	})
 	t.Run("options", func(t *testing.T) {
 		t.Parallel()
@@ -61,7 +61,7 @@ func testReflector(t *testing.T, reflector *Reflector, reflectionServiceFQN stri
 	t.Helper()
 	mux := http.NewServeMux()
 	mux.Handle(NewHandlerV1(reflector))
-	mux.Handle(NewHandlerV1Alpha1(reflector))
+	mux.Handle(NewHandlerV1Alpha(reflector))
 	server := httptest.NewUnstartedServer(mux)
 	server.EnableHTTP2 = true
 	server.StartTLS()


### PR DESCRIPTION
Buf's lint rules require "v1alpha1" as a version number, but the actual
gRPC protos use "v1alpha". This PR fixes this totally low-rent bug.
