### PR TITLE
Prep for v0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,11 @@ func main() {
 
 ## Status
 
-Like [`connect-go`][connect-go], `connect-grpcreflect-go` is a release
-candidate. We plan to tag further release candidates as necessary and a stable
-v1 soon after the Go 1.19 release.
+Like [`connect-go`][connect-go], `connect-grpcreflect-go` is a beta: we rely on
+it in production, but expect the Go community to quickly discover new patterns
+for working with generics. We plan to make backward-incompatible changes as
+necessary for the next few months, with the goal of tagging a stable v1 soon
+after the Go 1.19 release.
 
 ## Support and Versioning
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Offered under the [Apache 2 license][license].
 [APIv2]: https://blog.golang.org/protobuf-apiv2
 [BloomRPC]: https://github.com/bloomrpc/bloomrpc
 [Getting Started]: https://connect.build/go/getting-started
-[blog]: https://buf.build/blog/announcing-connect-a-better-grpc
+[blog]: https://buf.build/blog/connect-a-better-grpc
 [connect-go]: https://github.com/bufbuild/connect-go
 [demo]: https://github.com/bufbuild/connect-demo
 [docs]: https://connect.build

--- a/README.md
+++ b/README.md
@@ -55,11 +55,10 @@ func main() {
 
 ## Status
 
-Like [`connect-go`][connect-go], `connect-grpcreflect-go` is a beta: we rely on
-it in production, but expect the Go community to quickly discover new patterns
-for working with generics. We plan to make backward-incompatible changes as
-necessary for the next few months, with the goal of tagging a stable v1 soon
-after the Go 1.19 release.
+Like [`connect-go`][connect-go], this module is a beta: we rely on it in
+production, but we may make a few changes as we gather feedback from early
+adopters. We're planning to tag a stable v1 in October, soon after the Go 1.19
+release.
 
 ## Support and Versioning
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/bufbuild/connect-grpcreflect-go
 go 1.18
 
 require (
-	github.com/bufbuild/connect-go v0.0.0-20220520175512-2b3d3442ffb8
+	github.com/bufbuild/connect-go v0.1.0
 	github.com/google/go-cmp v0.5.8
 	google.golang.org/protobuf v1.28.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/bufbuild/connect-go v0.0.0-20220520175512-2b3d3442ffb8 h1:ZaD9cVYESl0sBAvcpmSO4wRbOSwS32F5wNPrnDw1XdE=
-github.com/bufbuild/connect-go v0.0.0-20220520175512-2b3d3442ffb8/go.mod h1:BajZGyRXK+Oq6Ddkm7atQ1Tu4W92OMpam7vyhFIf0ww=
+github.com/bufbuild/connect-go v0.1.0 h1:LxjZl0psAeiFuy3PIKoZpmixo3P6Dd+pLoy3QYVEAS0=
+github.com/bufbuild/connect-go v0.1.0/go.mod h1:4efZ2eXFENwd4p7tuLaL9m0qtTsCOzuBvrohvRGevDM=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=


### PR DESCRIPTION
Update README for v0.1.0 and upgrade to `connect-go` v0.1.0.