### PR TITLE
Disable goimports, rely on gci

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -34,6 +34,7 @@ linters:
     - funlen            # rely on code review to limit function length
     - gocognit          # dubious "cognitive overhead" quantification
     - gofumpt           # prefer standard gofmt
+    - goimports         # rely on gci instead
     - golint            # deprecated by Go team
     - gomnd             # some unnamed constants are okay
     - ifshort           # deprecated by author


### PR DESCRIPTION
We're already using GCI (since we enable all available linters by
default), so we can disable goimports. We're doing the same in core,
buf, and our other Go repos.
